### PR TITLE
remove "add genesis to the queue" from StartParsing

### DIFF
--- a/cmd/parse/parse.go
+++ b/cmd/parse/parse.go
@@ -100,11 +100,6 @@ func StartParsing(ctx *Context) error {
 	// Listen for and trap any OS signal to gracefully shutdown and exit
 	trapSignal(ctx)
 
-	if cfg.ParseGenesis {
-		// Add the genesis to the queue if requested
-		exportQueue <- 0
-	}
-
 	if cfg.ParseOldBlocks {
 		go enqueueMissingBlocks(exportQueue, ctx)
 	}

--- a/types/config/utils.go
+++ b/types/config/utils.go
@@ -16,11 +16,6 @@ func GetConfigFilePath() string {
 	return path.Join(HomePath, "config.yaml")
 }
 
-// GetGenesisFilePath returns the path to the genesis file
-func GetGenesisFilePath() string {
-	return path.Join(HomePath, "genesis.json")
-}
-
 // Write allows to write the given configuration into the file present at the given path
 func Write(cfg Config, path string) error {
 	bz, err := yaml.Marshal(&cfg)

--- a/types/config/utils.go
+++ b/types/config/utils.go
@@ -16,6 +16,11 @@ func GetConfigFilePath() string {
 	return path.Join(HomePath, "config.yaml")
 }
 
+// GetGenesisFilePath returns the path to the genesis file
+func GetGenesisFilePath() string {
+	return path.Join(HomePath, "genesis.json")
+}
+
 // Write allows to write the given configuration into the file present at the given path
 func Write(cfg Config, path string) error {
 	bz, err := yaml.Marshal(&cfg)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
<!-- Small description -->
Remove "adding genesis to the queue" for separating **bdjuno parse-genesis** from **bdjuno parse**
for PR forbole/bdjuno#257 (fix forbole/bdjuno#246)

## Checklist
- [x] Targeted PR against correct branch.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [x] Re-reviewed `Files changed` in the Github PR explorer.
