### PR TITLE
fix: stores not being registered correctly when using a local source

### DIFF
--- a/node/local/node.go
+++ b/node/local/node.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/codec"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"os"
 	"sort"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/types/tx"

--- a/node/remote/node.go
+++ b/node/remote/node.go
@@ -3,10 +3,11 @@ package remote
 import (
 	"context"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/codec"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"net/http"
 	"time"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	constypes "github.com/tendermint/tendermint/consensus/types"
 	tmjson "github.com/tendermint/tendermint/libs/json"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR fixes the registration of the various types of stores when accessing a local node. 

### Context
In order to access the local database properly, we need to re-create the same objects that the Cosmos SDK uses to write that DB. The objects are, in order: 
- the _database_ instance, that allows to perform low level operations (read/write) 
- the _commit multi-store_ that allows to query a specific state of the chain based on a height
- the _keepers_, which allow to perform high-level queries given a height and some parameters

So the call chain is the following: 
```
keepers -> commit multi-store -> database
```

The problem is that when creating the commit multi-store, since it handles multiple stores, the Cosmos SDK _registers_ the keys of all those stores inside such multi-store: the `x/bank` module registers a `bank` key, the `x/distribution` module a `distr` key and so on, for all the stores. All those keys are then later read then a query for those modules is performed. So the chain call now becomes: 
```
keys list -> distribution keeper -> commit multi-store -> distribution key -> database
```

If the **same** `distr` key that is created inside the app is **not** registered inside the commit multi-store that we use inside BDJuno (inside the local source), then we will end up with the `distribution key not registered` error. And this was exactly the problem. 

Now, since all the keys registered from the app are present inside a private field named `keys`, what I did was the following: 
1. use the reflection to get the value of that field
2. register all the keys properly 

This guarantees us that we are using the same keys that are also used to build the keeper that we use to query the data. The whole flow then looks something like this: 

1. the app builds the keys;
2. the app builds the keeper;
3. we use the keepers to build the various local sources and query the data easily;
4. we use the keys to build the main local source that allows to access the database.

## Checklist
- [ ] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
