### PR TITLE
fix: replace GetHeightRequestHeader with GetHeightRequestContext

### DIFF
--- a/node/remote/utils.go
+++ b/node/remote/utils.go
@@ -17,14 +17,6 @@ var (
 	HTTPProtocols = regexp.MustCompile("https?://")
 )
 
-// GetHeightRequestHeader returns the grpc.CallOption to query the state at a given height
-func GetHeightRequestHeader(height int64) grpc.CallOption {
-	header := metadata.New(map[string]string{
-		grpctypes.GRPCBlockHeightHeader: strconv.FormatInt(height, 10),
-	})
-	return grpc.Header(&header)
-}
-
 // GetHeightRequestContext adds the height to the context for querying the state at a given height
 func GetHeightRequestContext(context context.Context, height int64) context.Context {
 	return metadata.AppendToOutgoingContext(

--- a/node/remote/utils.go
+++ b/node/remote/utils.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"context"
 	"crypto/tls"
 	"regexp"
 	"strconv"
@@ -22,6 +23,15 @@ func GetHeightRequestHeader(height int64) grpc.CallOption {
 		grpctypes.GRPCBlockHeightHeader: strconv.FormatInt(height, 10),
 	})
 	return grpc.Header(&header)
+}
+
+// GetHeightRequestContext adds the height to the context for querying the state at a given height
+func GetHeightRequestContext(context context.Context, height int64) context.Context {
+	return metadata.AppendToOutgoingContext(
+		context,
+		grpctypes.GRPCBlockHeightHeader,
+		strconv.FormatInt(height, 10),
+	)
 }
 
 // MustCreateGrpcConnection creates a new gRPC connection using the provided configuration and panics on error


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
<!-- Small description -->
The height factor will work when it's added to the query context instead of query header. 

Found out while implementing hasura actions that the height sent with the header is actually not working. It will return the latest height info no matter which height is inputted. 

[Replacement example](https://github.com/forbole/bdjuno/blob/405453a568337469f128af6a3314cf46be748332/modules/bank/source/remote/source_actions.go#L15) where the height context works

## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [x] Re-reviewed `Files changed` in the Github PR explorer.
