### PR TITLE
feat: add `chain_id` label to prometheus to improve alert monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Changes
+- ([\#68](https://github.com/forbole/juno/pull/68)) Added `chain_id` label to prometheus to improve alert monitoring 
+
 ## v3.2.0
 ### Changes
 - ([\#61](https://github.com/forbole/juno/pull/61)) Updated v3 migration code to handle database users names with a hyphen 

--- a/logging/prometheus.go
+++ b/logging/prometheus.go
@@ -26,7 +26,7 @@ var WorkerHeight = prometheus.NewGaugeVec(
 		Name: "juno_last_indexed_height",
 		Help: "Height of the last indexed block.",
 	},
-	[]string{"worker_index"},
+	[]string{"worker_index", "chain_id"},
 )
 
 // ErrorCount represents the Telemetry counter used to track the number of errors emitted

--- a/parser/worker.go
+++ b/parser/worker.go
@@ -53,6 +53,10 @@ func NewWorker(ctx *Context, queue types.HeightQueue, index int) Worker {
 // given worker queue. Any failed job is logged and re-enqueued.
 func (w Worker) Start() {
 	logging.WorkerCount.Inc()
+	nodeInfo, err := w.node.Genesis()
+	if err != nil {
+		w.logger.Error("error while getting genesis info from the node ", "err", err)
+	}
 
 	for i := range w.queue {
 		if err := w.ProcessIfNotExists(i); err != nil {
@@ -64,7 +68,7 @@ func (w Worker) Start() {
 			}()
 		}
 
-		logging.WorkerHeight.WithLabelValues(fmt.Sprintf("%d", w.index)).Set(float64(i))
+		logging.WorkerHeight.WithLabelValues(fmt.Sprintf("%d", w.index), nodeInfo.Genesis.ChainID).Set(float64(i))
 	}
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
<!-- Small description -->
Fixes BDU-280
- Added `chain_id` label to prometheus’ `juno_last_indexed_height` metric

## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [x] Re-reviewed `Files changed` in the Github PR explorer.
