### PR TITLE
feat: allow to handle MsgExec instances properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Changes
+- ([\#75](https://github.com/forbole/juno/pull/75)) Allow modules to handle MsgExec inner messages
+
 ## v3.4.0
 ### Changes
 - ([\#71](https://github.com/forbole/juno/pull/71)) Retry RPC client connection upon failure instead of panic

--- a/modules/module.go
+++ b/modules/module.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/cosmos/cosmos-sdk/x/authz"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/go-co-op/gocron"
 	tmctypes "github.com/tendermint/tendermint/rpc/core/types"
@@ -91,9 +93,18 @@ type TransactionModule interface {
 
 type MessageModule interface {
 	// HandleMsg handles a single message.
-	// For convenience of usa, the index of the message inside the transaction and the transaction itself
+	// For convenience of use, the index of the message inside the transaction and the transaction itself
 	// are passed as well.
 	// NOTE. The returned error will be logged using the MsgError method. All other modules' handlers
 	// will still be called.
 	HandleMsg(index int, msg sdk.Msg, tx *types.Tx) error
+}
+
+type AuthzMessageModule interface {
+	// HandleMsgExec handles a single message that is contained within an authz.MsgExec instance.
+	// For convenience of use, the index of the message inside the transaction and the transaction itself
+	// are passed as well.
+	// NOTE. The returned error will be logged using the MsgError method. All other modules' handlers
+	// will still be called.
+	HandleMsgExec(index int, msgExec *authz.MsgExec, authzMsgIndex int, executedMsg sdk.Msg, tx *types.Tx) error
 }

--- a/parser/worker.go
+++ b/parser/worker.go
@@ -314,7 +314,7 @@ func (w Worker) handleMessage(index int, msg sdk.Msg, tx *types.Tx) {
 
 			for _, module := range w.modules {
 				if messageModule, ok := module.(modules.AuthzMessageModule); ok {
-					err := messageModule.HandleMsgExec(index, msgExec, authzIndex, executedMsg, tx)
+					err = messageModule.HandleMsgExec(index, msgExec, authzIndex, executedMsg, tx)
 					if err != nil {
 						w.logger.MsgError(module, tx, executedMsg, err)
 					}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR adds the possibility of handling `MsgExec` inner messages. 

Currently when a `MsgExec` is executed, the inner messages are not parsed correctly by the various modules. With this PR a new `AuthzMessageModule` interface is added. Thanks to this, modules will be able to properly handle `MsgExec` inner messages and parse their data accordingly.

## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [x] Re-reviewed `Files changed` in the Github PR explorer.
