### PR TITLE
fix: return 0 height inside GetLastBlockHeight if there are no blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Changes
 - ([\#74](https://github.com/forbole/juno/pull/74)) Added database block count to prometheus to improve alert monitoring
 - ([\#75](https://github.com/forbole/juno/pull/75)) Allow modules to handle MsgExec inner messages
+- ([\#76](https://github.com/forbole/juno/pull/76)) Replace `return err` with `log.Error()` for `GetLastBlockHeight()` method in parse blocks cmd
 
 ## v3.4.0
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### Changes
 - ([\#74](https://github.com/forbole/juno/pull/74)) Added database block count to prometheus to improve alert monitoring
 - ([\#75](https://github.com/forbole/juno/pull/75)) Allow modules to handle MsgExec inner messages
-- ([\#76](https://github.com/forbole/juno/pull/76)) Replace `return err` with `log.Error()` for `GetLastBlockHeight()` method in parse blocks cmd
+- ([\#76](https://github.com/forbole/juno/pull/76)) Return 0 as height for `GetLastBlockHeight()` method while no block is saved
 
 ## v3.4.0
 ### Changes

--- a/cmd/parse/blocks/blocks.go
+++ b/cmd/parse/blocks/blocks.go
@@ -47,7 +47,7 @@ will be replaced with the data downloaded from the node.
 
 			lastDbBlockHeight, err := parseCtx.Database.GetLastBlockHeight()
 			if err != nil {
-				log.Error().Msgf("error while getting last DB block height: %s", err.Error())
+				return err
 			}
 
 			// Compare start height from config file and last block height in database

--- a/cmd/parse/blocks/blocks.go
+++ b/cmd/parse/blocks/blocks.go
@@ -47,7 +47,7 @@ will be replaced with the data downloaded from the node.
 
 			lastDbBlockHeight, err := parseCtx.Database.GetLastBlockHeight()
 			if err != nil {
-				return err
+				log.Error().Msgf("error while getting last DB block height: %s", err.Error())
 			}
 
 			// Compare start height from config file and last block height in database

--- a/database/postgresql/postgresql.go
+++ b/database/postgresql/postgresql.go
@@ -101,7 +101,12 @@ func (db *Database) GetLastBlockHeight() (int64, error) {
 	stmt := `SELECT height FROM block ORDER BY height DESC LIMIT 1;`
 
 	var height int64
-	if err := db.Sql.QueryRow(stmt).Scan(&height); err != nil {
+	err := db.Sql.QueryRow(stmt).Scan(&height)
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows in result set") {
+			// If no rows stored in block table, return 0 as height
+			return 0, nil
+		}
 		return 0, fmt.Errorf("error while getting last block height, error: %s", err)
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
<!-- Small description -->

When we use the parse blocks command, in case that the database is empty, `return err` here will error out the program and not continuing parsing the desired block height. Replacing it here so it's more handy for dev purpose when we need to just test specific heights. (we don't have to run ` start cmd` before using `parse blocks all`)

## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [x] Re-reviewed `Files changed` in the Github PR explorer.
