### PR TITLE
fix: add wait group to handle message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - ([\#74](https://github.com/forbole/juno/pull/74)) Added database block count to prometheus to improve alert monitoring
 - ([\#75](https://github.com/forbole/juno/pull/75)) Allow modules to handle MsgExec inner messages
 - ([\#76](https://github.com/forbole/juno/pull/76)) Return 0 as height for `GetLastBlockHeight()` method if there are no blocks saved in database
+- ([\#77](https://github.com/forbole/juno/pull/77)) Add wait group to handle messages concurrently
 - ([\#79](https://github.com/forbole/juno/pull/79)) Use `sqlx` instead of `sql` while dealing with a PostgreSQL database
 - ([\#83](https://github.com/forbole/juno/pull/83)) Bump `github.com/tendermint/tendermint` to `v0.34.22`
 

--- a/database/postgresql/postgresql.go
+++ b/database/postgresql/postgresql.go
@@ -101,12 +101,13 @@ func (db *Database) GetLastBlockHeight() (int64, error) {
 	stmt := `SELECT height FROM block ORDER BY height DESC LIMIT 1;`
 
 	var height int64
-	if err := db.SQL.QueryRow(stmt).Scan(&height); err != nil {
+	err := db.SQL.QueryRow(stmt).Scan(&height)
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows in result set") {
+			// If no rows stored in block table, return 0 as height
+			return 0, nil
+		}
 		return 0, fmt.Errorf("error while getting last block height, error: %s", err)
-	}
-
-	if height == 0 {
-		return 0, fmt.Errorf("cannot get block height, no blocks saved")
 	}
 
 	return height, nil

--- a/database/postgresql/postgresql.go
+++ b/database/postgresql/postgresql.go
@@ -105,6 +105,10 @@ func (db *Database) GetLastBlockHeight() (int64, error) {
 		return 0, fmt.Errorf("error while getting last block height, error: %s", err)
 	}
 
+	if height == 0 {
+		return 0, fmt.Errorf("cannot get block height, no blocks saved")
+	}
+
 	return height, nil
 }
 

--- a/parser/worker.go
+++ b/parser/worker.go
@@ -363,6 +363,7 @@ func (w Worker) ExportTxs(txs []*types.Tx) error {
 				w.handleMessage(i, sdkMsg, tx)
 			}(i, sdkMsg)
 		}
+		wg.Wait()
 	}
 
 	totalBlocks := w.db.GetTotalBlocks()

--- a/parser/worker.go
+++ b/parser/worker.go
@@ -279,17 +279,16 @@ func (w Worker) saveTx(tx *types.Tx) error {
 }
 
 // handleTx accepts the transaction and calls the tx handlers.
-func (w Worker) handleTx(tx *types.Tx) error {
+func (w Worker) handleTx(tx *types.Tx) {
 	// Call the tx handlers
 	for _, module := range w.modules {
 		if transactionModule, ok := module.(modules.TransactionModule); ok {
 			err := transactionModule.HandleTx(tx)
 			if err != nil {
-				return err
+				w.logger.TxError(module, tx, err)
 			}
 		}
 	}
-	return nil
 }
 
 // handleMessage accepts the transaction and handles messages contained


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
<!-- Small description -->

This PR adds wait group to handle messages concurrently. 

Background: 
When I used `parse blocks`cmd to parse 1 specific height that has transactions & messages,  the messages can be lost because of being handled through go routines and when the main program is done, all go routines are closed. 

## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [x] Re-reviewed `Files changed` in the Github PR explorer.
