### PR TITLE
feat: remove concurrent transactions and messages handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - ([\#79](https://github.com/forbole/juno/pull/79)) Use `sqlx` instead of `sql` while dealing with a PostgreSQL database
 - ([\#83](https://github.com/forbole/juno/pull/83)) Bump `github.com/tendermint/tendermint` to `v0.34.22`
 - ([\#84](https://github.com/forbole/juno/pull/84)) Replace database configuration params with URI
+- ([\#86](https://github.com/forbole/juno/pull/86)) Revert concurrent handling of transactions and messages
 
 ## v3.4.0
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 - ([\#74](https://github.com/forbole/juno/pull/74)) Added database block count to prometheus to improve alert monitoring
 - ([\#75](https://github.com/forbole/juno/pull/75)) Allow modules to handle MsgExec inner messages
 - ([\#76](https://github.com/forbole/juno/pull/76)) Return 0 as height for `GetLastBlockHeight()` method if there are no blocks saved in database
-- ([\#77](https://github.com/forbole/juno/pull/77)) Add wait group to handle messages concurrently
 - ([\#79](https://github.com/forbole/juno/pull/79)) Use `sqlx` instead of `sql` while dealing with a PostgreSQL database
 - ([\#83](https://github.com/forbole/juno/pull/83)) Bump `github.com/tendermint/tendermint` to `v0.34.22`
 - ([\#84](https://github.com/forbole/juno/pull/84)) Replace database configuration params with URI

--- a/parser/worker.go
+++ b/parser/worker.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"encoding/json"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/x/authz"
@@ -328,23 +327,18 @@ func (w Worker) handleMessage(index int, msg sdk.Msg, tx *types.Tx) {
 // ExportTxs accepts a slice of transactions and persists then inside the database.
 // An error is returned if the write fails.
 func (w Worker) ExportTxs(txs []*types.Tx) error {
-	var wg sync.WaitGroup
-
+	// handle all transactions inside the block
 	for _, tx := range txs {
-		// Save the transaction
+		// save the transaction
 		err := w.saveTx(tx)
 		if err != nil {
 			return fmt.Errorf("error while storing txs: %s", err)
 		}
 
-		// Handle the transaction concurrently
-		wg.Add(1)
-		go func(tx *types.Tx) {
-			defer wg.Done()
-			w.handleTx(tx)
-		}(tx)
+		// call the tx handlers
+		w.handleTx(tx)
 
-		// Parse all the messages contained inside the transaction
+		// handle all messages contained inside the transaction
 		sdkMsgs := make([]sdk.Msg, len(tx.Body.Messages))
 		for i, msg := range tx.Body.Messages {
 			var stdMsg sdk.Msg
@@ -355,18 +349,11 @@ func (w Worker) ExportTxs(txs []*types.Tx) error {
 			sdkMsgs[i] = stdMsg
 		}
 
-		// Handle all the messages concurrently
+		// call the msg handlers
 		for i, sdkMsg := range sdkMsgs {
-			wg.Add(1)
-			go func(i int, sdkMsg sdk.Msg) {
-				defer wg.Done()
-				w.handleMessage(i, sdkMsg, tx)
-			}(i, sdkMsg)
+			w.handleMessage(i, sdkMsg, tx)
 		}
 	}
-
-	// Wait all transactions and messages to be parsed
-	wg.Wait()
 
 	totalBlocks := w.db.GetTotalBlocks()
 	logging.DbBlockCount.WithLabelValues("total_blocks_in_db").Set(float64(totalBlocks))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR removes the concurrent handling of transactions and messages. This is because it might cause some wrongful handling then a transaction contains messages that perform opposite operations.

As an example, consider a transaction that contains, in the given order: 

- one `MsgRevokeFeeAllowance` from Alice to Bob
- one `MsgGrantFeeAllowance` from Alice to Bob

If those messages are handled concurrently, since concurrency does not guarantee the order of handling, the following cases are both likely to happen:

1. the `MsgRevokeFeeAllowance` gets handled before `MsgGrantFeeAllowance`
2. the `MsgGrantFeeAllowance` gets handled before `MsgRevokeFeeAllowance`

If the parser is storing the existing fee allowances, then the following results are equally likely to happen:

1. the database wil contain the proper fee allowance (if `MsgRevokeFeeAllowance` gets handled before `MsgGrantFeeAllowance`), or
2. the database will not contain the fee allowance (if `MsgGrantFeeAllowance` gets handled before `MsgRevokeFeeAllowance`) 

Obviously, the second case is not the correct one and is only due to the concurrent handling of messages.

The same might happen on a transaction level, with two transactions containing similar messages.

To solve this, we need to remove the concurrent handling of transactions and messages.

## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
