### PR TITLE
fix: init command build empty config file

### DIFF
--- a/types/config/config.go
+++ b/types/config/config.go
@@ -42,15 +42,23 @@ func NewConfig(
 }
 
 func DefaultConfig() Config {
-	return NewConfig(
+	cfg := NewConfig(
 		nodeconfig.DefaultConfig(),
 		DefaultChainConfig(), databaseconfig.DefaultDatabaseConfig(),
 		parserconfig.DefaultParsingConfig(), loggingconfig.DefaultLoggingConfig(),
 	)
+
+	bz, err := yaml.Marshal(cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	cfg.bytes = bz
+	return cfg
 }
 
 func (c Config) GetBytes() ([]byte, error) {
-	return yaml.Marshal(c)
+	return c.bytes, nil
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/types/config/config.go
+++ b/types/config/config.go
@@ -7,6 +7,7 @@ import (
 	loggingconfig "github.com/forbole/juno/v5/logging/config"
 	nodeconfig "github.com/forbole/juno/v5/node/config"
 	parserconfig "github.com/forbole/juno/v5/parser/config"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -49,7 +50,7 @@ func DefaultConfig() Config {
 }
 
 func (c Config) GetBytes() ([]byte, error) {
-	return c.bytes, nil
+	return yaml.Marshal(c)
 }
 
 // ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
<!-- Small description -->

This PR intends to fix the init command building empty config instead of the default config since `bytes` value of `DefaultConfig` built by constructor is `nil`.

## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [x] Re-reviewed `Files changed` in the Github PR explorer.
