### PR TITLE
fix: initialize involved accounts addresses to empty slice instead of nil

### DIFF
--- a/modules/messages/types.go
+++ b/modules/messages/types.go
@@ -23,7 +23,7 @@ func DefaultMessagesParser(tx *types.Transaction) ([]string, error) {
 // function to remove duplicate values
 func removeDuplicates(s []string) []string {
 	bucket := make(map[string]bool)
-	var result []string
+	result := []string{}
 	for _, str := range s {
 		if _, ok := bucket[str]; !ok {
 			bucket[str] = true
@@ -33,8 +33,8 @@ func removeDuplicates(s []string) []string {
 	return result
 }
 
-func parseAddressesFromEvents(tx *types.Transaction) []string {
-	var addresses []string
+func parseAddressesFromEvents(tx *types.Tx) []string {
+	addresses := []string{}
 	for _, event := range tx.Events {
 		for _, attribute := range event.Attributes {
 			// Try parsing the address as a validator address

--- a/modules/messages/types.go
+++ b/modules/messages/types.go
@@ -33,7 +33,7 @@ func removeDuplicates(s []string) []string {
 	return result
 }
 
-func parseAddressesFromEvents(tx *types.Tx) []string {
+func parseAddressesFromEvents(tx *types.Transaction) []string {
 	addresses := []string{}
 	for _, event := range tx.Events {
 		for _, attribute := range event.Attributes {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
<!-- Small description -->

Currently, our messages table has a field called `involved_accounts_addresses` which is parsed from `tx.events` and it does not allow `NULL` value. However, it might be a nil slice when a transaction does not include the event related to addresses, so error messages could happen:
```bash
ERR error while handling message err="pq: null value in column \"involved_accounts_addresses\" of relation \"message_68\" violates not-null constraint" height=6808106 module=messages msg_type=/canine_chain.storage.MsgRequestReportForm tx_hash=0F587A0BE501C2DFCA092A5640D3652179567FECFEBE4B98340FA6BB4D3F25DA
```

References:
https://bigdipper.live/jackal/transactions/0F587A0BE501C2DFCA092A5640D3652179567FECFEBE4B98340FA6BB4D3F25DA

## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [x] Re-reviewed `Files changed` in the Github PR explorer.
