### PR TITLE
fix: replace message-related field into JSON type from JSONB

### DIFF
--- a/database/postgresql/schema.sql
+++ b/database/postgresql/schema.sql
@@ -36,7 +36,7 @@ CREATE TABLE transaction
     success      BOOLEAN NOT NULL,
 
     /* Body */
-    messages     JSONB   NOT NULL DEFAULT '[]'::JSONB,
+    messages     JSON    NOT NULL DEFAULT '[]'::JSON,
     memo         TEXT,
     signatures   TEXT[]  NOT NULL,
 
@@ -64,7 +64,7 @@ CREATE TABLE message
     transaction_hash            TEXT   NOT NULL,
     index                       BIGINT NOT NULL,
     type                        TEXT   NOT NULL,
-    value                       JSONB  NOT NULL,
+    value                       JSON   NOT NULL,
     involved_accounts_addresses TEXT[] NOT NULL,
 
     /* PSQL partition */


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
<!-- Small description -->
This PR intends to fix the issue that message JSON may includes invalid Unicode sequence \u0000, it would cause the error when saving transactions and messages into Database.

Reference:
[Invalid unicode sequence on PostgreSQL](https://stackoverflow.com/questions/68303357/how-to-insert-json-containing-escape-codes-into-a-jsonb-column-in-postgresql-usi)
[Jackal transaction including invalid unicode sequence](https://api.jackal.forbole.com/cosmos/tx/v1beta1/txs/0C51E15736E66F17D26E2FB93E3591E81E9C0D3F7477D9F0DA383B037CB23CC1)

## Checklist
- [ ] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
